### PR TITLE
debugger command for mac

### DIFF
--- a/_TZ1/scripts/debugger_mac
+++ b/_TZ1/scripts/debugger_mac
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <ELF FILE>"
+  exit 1
+fi
+
+OCD_DIR=$(brew --prefix openocd)
+OCD_CFG_DIR=${OCD_DIR}/share/openocd/scripts
+
+openocd -s ${OCD_CFG_DIR} -f interface/cmsis-dap.cfg -f target/tz10xx.cfg &
+OCD_PID=$!
+
+sleep 1
+if ! kill -0 ${OCD_PID} > /dev/null 2>&1; then
+  echo "Failed to launch openocd..."
+  exit 1
+fi
+
+${TOOL_DIR}/arm-none-eabi-gdb -ex "target remote localhost:3333" -ex "monitor reset init" $1
+
+kill ${OCD_PID} > /dev/null 2>&1 || echo "OpenOCD is already finished"
+echo "debugger finished."

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,7 +1,13 @@
 #! /bin/bash
 
-export TZ1_BASE=../Cerevo/CDP-TZ01B/
-export INSTALL_FILES=install_files/
+if ! brew list openocd > /dev/null 2>&1; then
+  echo "This script requires openocd installed by Homebrew!"
+  exit 1
+fi
+
+TZ1_BASE=../Cerevo/CDP-TZ01B/
+INSTALL_FILES=install_files/
+OCD_HOME=$(brew --prefix openocd)
 
 cd ${INSTALL_FILES}
 
@@ -29,12 +35,12 @@ if [ ! -e ${TZ1_BASE}sdk/ARM.CMSIS ]; then
 	mkdir ${TZ1_BASE}sdk/ARM.CMSIS
 fi
 
-if [ -e "ARM.CMSIS.4.5.0.pack" ]; then
-	unzip -qd ${TZ1_BASE}sdk/ARM.CMSIS ARM.CMSIS.4.5.0.pack
-elif [ -e "ARM.CMSIS.4.5.0.zip" ]; then
-	unzip -qd ${TZ1_BASE}sdk/ARM.CMSIS ARM.CMSIS.4.5.0.zip
+if [ -e "ARM.CMSIS.3.20.4.pack" ]; then
+	unzip -qd ${TZ1_BASE}sdk/ARM.CMSIS ARM.CMSIS.3.20.4.pack
+elif [ -e "ARM.CMSIS.3.20.4.zip" ]; then
+	unzip -qd ${TZ1_BASE}sdk/ARM.CMSIS ARM.CMSIS.3.20.4.zip
 else 
-	echo "ARM.CMSIS.4.5.0 is notfound."	
+	echo "ARM.CMSIS.3.20.4 is notfound."
 	exit
 fi
 
@@ -55,6 +61,9 @@ ${TZ1_BASE}tools/bin/arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -mthumb-interwork
 
 echo "This script doesn't install OpenOCD."
 echo "OpenOCD can be installed by using apt."
+
+cp tz10xx.cfg ${OCD_HOME}/share/openocd/scripts/target/
+cp tz10xx_reset.tcl ${OCD_HOME}/share/openocd/scripts/target/
 
 echo "Setup Scripts."
 cp -r ../_TZ1/* ${TZ1_BASE}


### PR DESCRIPTION
OpenOCD周りの設定を`install_mac.sh`でコピーする処理の追加と、`debugger_mac`コマンドの追加です。
Homebrew前提になってしまっていますが良ければ見てみてください。
